### PR TITLE
Add vendor utils to selection flow

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -34,3 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Vendor Selection
+
+After signing up and completing your basic profile, you will be redirected to the vendor selection page. Here you can choose one or more grocery vendors (e.g. Publix, Walmart, Trader Joe's).
+
+1. Use the checkboxes to mark your preferred vendors.
+2. Click **Save Preferences** to store them in your profile.
+
+The list of available vendors comes from `getVendorKeys()` in `frontend/services/vendorUtils.ts`, keeping the UI in sync with our scraping modules.

--- a/frontend/app/profile-setup/page.tsx
+++ b/frontend/app/profile-setup/page.tsx
@@ -58,7 +58,7 @@ export default function ProfileSetupPage() {
     if (dbError) {
       setError(dbError.message);
     } else {
-      router.push('/');
+      router.push('/vendor-selection');
     }
   };
 

--- a/frontend/app/vendor-selection/page.tsx
+++ b/frontend/app/vendor-selection/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { getVendorKeys } from '../../services/vendorUtils';
+import { supabase } from '../../services/supabaseClient';
+
+export default function VendorSelectionPage() {
+  const router = useRouter();
+  const vendors = getVendorKeys();
+  const [selected, setSelected] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load existing preferences and ensure auth
+  useEffect(() => {
+    async function load() {
+      const {
+        data: { user }
+      } = await supabase.auth.getUser();
+      if (!user) {
+        router.push('/signin');
+        return;
+      }
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('preferred_vendors')
+        .eq('user_id', user.id)
+        .single();
+      if (data?.preferred_vendors) {
+        setSelected(data.preferred_vendors);
+      }
+      if (error) {
+        setError(error.message);
+      }
+      setLoading(false);
+    }
+    load();
+  }, [router]);
+
+  const toggleVendor = (vendor: string) => {
+    setSelected(current =>
+      current.includes(vendor)
+        ? current.filter(v => v !== vendor)
+        : [...current, vendor]
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    const {
+      data: { user }
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setError('Not authenticated');
+      setLoading(false);
+      return;
+    }
+    const { error } = await supabase
+      .from('profiles')
+      .update({ preferred_vendors: selected })
+      .eq('user_id', user.id);
+    setLoading(false);
+    if (error) {
+      setError(error.message);
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-4">
+      <h1 className="text-2xl font-bold mb-4">Select Preferred Vendors</h1>
+      {error && <p className="text-red-500 mb-2">{error}</p>}
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {vendors.map(vendor => (
+            <label key={vendor} className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={selected.includes(vendor)}
+                onChange={() => toggleVendor(vendor)}
+              />
+              <span className="capitalize">{vendor}</span>
+            </label>
+          ))}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 text-white p-2 rounded"
+          >
+            {loading ? 'Saving...' : 'Save Preferences'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/services/__tests__/vendorUtils.test.ts
+++ b/frontend/services/__tests__/vendorUtils.test.ts
@@ -1,0 +1,8 @@
+import { getVendorKeys } from '../vendorUtils';
+import config from '../config.json';
+
+describe('getVendorKeys', () => {
+  it('returns all vendors from config', () => {
+    expect(getVendorKeys().sort()).toEqual(Object.keys(config).sort());
+  });
+});

--- a/frontend/services/vendorUtils.ts
+++ b/frontend/services/vendorUtils.ts
@@ -1,0 +1,8 @@
+import config from './config.json';
+
+/**
+ * Returns the vendor keys defined in config.json.
+ */
+export function getVendorKeys(): string[] {
+  return Object.keys(config);
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
       tsconfig: 'tsconfig.json'
     }
   },
-  roots: ['<rootDir>/frontend/services/vendorScrapers'],
+  roots: ['<rootDir>/frontend/services'],
   testMatch: ['**/__tests__/**/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: {

--- a/supabase/migrations/20250628_add_preferred_vendors.sql
+++ b/supabase/migrations/20250628_add_preferred_vendors.sql
@@ -1,0 +1,3 @@
+-- 2025-06-28: Add preferred_vendors column to profiles
+ALTER TABLE profiles
+  ADD COLUMN preferred_vendors TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/task_history_document.md
+++ b/task_history_document.md
@@ -13,7 +13,7 @@ This document tracks all major tasks, milestones, and operational events for the
 | 5       | Implement user authentication/profile            | Completed | WithA        | 06/26/2025     | Supabase Auth and profile setup implemented (signup, signin, profile, context, routing) |
 | 6       | Model ingredient & meal data (from recipe book)  | Completed | WithA        | 06/26/2025     | SQL schema created; ingredients seeded via scripts (codes from recipe book) |
 | 7       | Build vendor scraping modules                    | Completed | WithA        | 06/27/2025      | Implemented scraping modules with simulated pages; live selectors to be added post-MVP. |
-| 8       | Vendor selection UI                              | Pending  | -            | -              | -                                      |
+| 8       | Vendor selection UI                              | Completed | WithA        | 06/27/2025      | Implemented vendor preference page and DB column (commit 7ba84bc) |
 | 9       | Meal suggestion engine                           | Pending  | -            | -              | -                                      |
 | 10      | Swipable meal ticket UI                          | Pending  | -            | -              | -                                      |
 | 11      | Cart & checkout flow                             | Pending  | -            | -              | -                                      |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "paths": {}
   },
   "include": [
-    "frontend/services/vendorScrapers",
-    "frontend/services/vendorScrapers/__tests__"
+    "frontend/services/**/*"
   ]
 }


### PR DESCRIPTION
## Summary
- reference vendorUtils in vendor-selection page
- document vendorUtils usage in README
- update task history with final commit reference

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f156d28d48320a6a5192115706d23