### PR TITLE
Fix build by adding puppeteer dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "autoprefixer": "^10.4.21",
     "bufferutil": "^4.0.9",
     "next": "15.3.4",
+    "puppeteer": "^24.11.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-native-svg": "^15.12.0",


### PR DESCRIPTION
## Summary
- add `puppeteer` dependency to frontend package.json so Next.js build finds it

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68600b22bd488320b1b65a3c9c38065d